### PR TITLE
Fix widget URL for Oxid EE and Varnish caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ This module extends the `oxConfig::_checkSsl` method and adds an additional chec
 
 There is a fragment of code in OXID CE which checks if `HTTP_X_FORWARDED_SERVER` is set to `ssl`, however,
 `HTTP_X_FORWARDED_SERVER` is probably the wrong variable to check.
+
+Additionally, the module changes the URL of widgets to always be non-SSL as Varnish can't do SSL and in turn widget
+requests can't be done by Varnish, which breaks the whole caching mechanism (this is only for OXID EE with additional
+license for the Varnish option).

--- a/core/oxidVarnishSSLFix.php
+++ b/core/oxidVarnishSSLFix.php
@@ -1,15 +1,35 @@
 <?php
 
+/**
+ * Extension of class oxConfig.
+ */
 class oxidVarnishSSLFix extends oxidVarnishSSLFix_parent {
-    protected function _checkSsl()
-    {
-        parent::_checkSsl();
 
-        $myUtilsServer = oxRegistry::get("oxUtilsServer");
-        $aServerVars = $myUtilsServer->getServerVar();
+	/**
+	 * Extend SSL check to respect header HTTP_X_FORWARDED_PROTO sent by proxy server in front of Oxid.
+	 */
+	protected function _checkSsl() {
+		parent::_checkSsl();
 
-        if (isset($aServerVars['HTTP_X_FORWARDED_PROTO']) && $aServerVars['HTTP_X_FORWARDED_PROTO'] == 'https') {
-            $this->setIsSsl(true);
-        }
-    }
+		$myUtilsServer = oxRegistry::get('oxUtilsServer');
+		$aServerVars = $myUtilsServer->getServerVar();
+
+		if (isset($aServerVars['HTTP_X_FORWARDED_PROTO']) && $aServerVars['HTTP_X_FORWARDED_PROTO'] == 'https') {
+			$this->setIsSsl(TRUE);
+		}
+	}
+
+	/**
+	 * Returns widget non-SSL URL including widget.php and sid.
+	 *
+	 * @param int $iLang Current language
+	 * @param bool $blAdmin Called in admin?
+	 * @return string
+	 */
+	public function getWidgetUrl($iLang = NULL, $blAdmin = NULL) {
+		$sUrl = $this->getShopUrl($iLang, $blAdmin);
+
+		return oxRegistry::get('oxUtilsUrl')->processUrl($sUrl . 'widget.php', FALSE);
+	}
+
 }


### PR DESCRIPTION
Thanks for your great work, I've extended the module by a fix for the widget URL that OXID generates when Varnish caching is activated in OXID EE; these widget URLs have to be non-SSL all the time as Varnish can't handle SSL.
